### PR TITLE
chore: add PWA icon generator script and basic pnpm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm i -w
+      - run: pnpm test
+      - run: pnpm build:web

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "symbios",
+  "private": true,
+  "packageManager": "pnpm@9.0.0",
+  "scripts": {
+    "test": "pnpm -r test",
+    "build:web": "pnpm --filter frontend build",
+    "lint": "echo 'add eslint here' && exit 0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "frontend"

--- a/scripts/make-icons.sh
+++ b/scripts/make-icons.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage(){
+  cat <<USG
+Uso:
+  $0 -i <logo.png> [-o <dir-saida>]
+Exemplo:
+  $0 -i apps/xplore/public/branding/mv-xplore-logo.png -o apps/xplore/public/icons
+USG
+}
+
+SRC=""
+OUTDIR="public/icons"
+SIZES=(16 32 48 72 96 128 144 152 167 180 192 256 384 512)
+
+while getopts "i:o:h" opt; do
+  case "$opt" in
+    i) SRC="$OPTARG";;
+    o) OUTDIR="$OPTARG";;
+    h) usage; exit 0;;
+    *) usage; exit 1;;
+  esac
+done
+
+[ -n "$SRC" ] || { usage >&2; exit 1; }
+[ -f "$SRC" ] || { echo "Arquivo não encontrado: $SRC" >&2; exit 1; }
+
+command -v convert >/dev/null || { echo "ImageMagick (convert) não encontrado" >&2; exit 1; }
+
+mkdir -p "$OUTDIR"
+for s in "${SIZES[@]}"; do
+  convert "$SRC" -resize "${s}x${s}" "$OUTDIR/icon-${s}.png"
+  echo "Gerado: $OUTDIR/icon-${s}.png"
+done


### PR DESCRIPTION
## Summary
- add helper script to generate PWA icons from a logo using ImageMagick
- introduce pnpm workspace setup and simple CI workflow

## Testing
- `./scripts/make-icons.sh -i dummy_logo.png -o tmp_icons` *(fails: ImageMagick (convert) não encontrado)*
- `(cd frontend && npm test)`
- `python -m py_compile backend/main.py backend/llm_proxy.py`
- `pnpm i -w` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68c60a7ffa648326956abb0e0155a7eb