### PR TITLE
Add troubleshooting and connectivity scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 frontend/dist
+logs/
 __pycache__
 *.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # SymbiOS
-SimbiOS/LUA A ponte entre a intenção humana e a execução tecnológica, redefinindo a interação com sistemas.
+
+SimbiOS/LUA é a ponte entre a intenção humana e a execução tecnológica, redefinindo a interação com sistemas.
+
+## 📦 Scripts de Consolidação e Operação
+
+Este repositório agora contém uma suíte completa de scripts para apoiar a consolidação do ecossistema MatVerse em um monorepo e orquestrar suas operações:
+
+- `scripts/consolidation/migrate-to-monorepo.sh` — executa a migração automatizada dos repositórios legados para a estrutura consolidada.
+- `scripts/consolidation/archive-repositories.sh` — automatiza o arquivamento dos repositórios antigos no GitHub.
+- `scripts/verification/verify-consolidation.sh` — valida se a estrutura do monorepo está íntegra e se os builds essenciais funcionam.
+- `scripts/verification/verify-lakehouse.sh` — verifica a saúde do ambiente Lakehouse local, incluindo MinIO, Trino e Redis.
+- `scripts/verification/final-checklist.sh` — checklist interativo antes da liberação para produção.
+- `scripts/verification/verify-deployment.sh` — confirma o estado do deploy em clusters Kubernetes.
+- `scripts/deployment/deploy-production.sh` — empacota imagens Docker e aplica as configurações de infraestrutura para o ambiente desejado.
+- `scripts/status/healthcheck.sh` — gera um relatório rápido de saúde da stack.
+- `scripts/quickstart.sh` — realiza a inicialização rápida da infraestrutura local com Docker Compose.
+- `scripts/start-with-fallback.sh` — inicializa os serviços com retentativas e geração de logs para cada componente.
+- `scripts/quick-check.sh` — executa verificações rápidas de ambiente e pré-requisitos.
+- `scripts/test/connectivity-test.sh` — valida conectividade externa e portas locais essenciais.
+- `scripts/troubleshooting/diagnose-fix.sh` — diagnostica o ambiente e aplica correções automáticas.
+- `scripts/troubleshooting/fix-common-issues.sh` — corrige problemas recorrentes como permissões e dependências quebradas.
+- `scripts/debug/generate-debug-report.sh` — consolida informações de sistema e logs para análise detalhada.
+
+Cada script está documentado com comentários internos e valida pré-requisitos para evitar falhas silenciosas.

--- a/scripts/consolidation/archive-repositories.sh
+++ b/scripts/consolidation/archive-repositories.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/consolidation/archive-repositories.sh
+#
+# Archives legacy repositories once the MatVerse monorepo is established.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🗃️" "Arquivando repositórios antigos..."
+printf '====================================%s\n' ""
+
+REPOS=(
+  "matverse-explore"
+  "SymbiOS-public"
+)
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  log "❌" "GITHUB_TOKEN não definido."
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  log "❌" "curl não encontrado."
+  exit 1
+fi
+
+for repo in "${REPOS[@]}"; do
+  log "📦" "Arquivando $repo..."
+
+  response=$(curl -s -o /tmp/github-archive-response.json -w "%{http_code}" \
+    -X PATCH \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/xMatVerse/$repo" \
+    -d '{"name":"'$repo'-archived", "archived":true}')
+
+  if [[ "$response" != "200" ]]; then
+    log "❌" "Falha ao arquivar $repo (HTTP $response). Consulte /tmp/github-archive-response.json."
+    continue
+  fi
+
+  issue_response=$(curl -s -o /tmp/github-archive-issue.json -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/xMatVerse/$repo-archived/issues" \
+    -d '{"title":"Repository Archived", "body":"This repository has been archived and consolidated into [xMatVerse monorepo](https://github.com/xMatVerse/xMatVerse). All future development will occur in the monorepo."}')
+
+  if [[ "$issue_response" != "201" ]]; then
+    log "⚠️" "Repositório arquivado, mas não foi possível criar o aviso (HTTP $issue_response)."
+  else
+    log "✅" "$repo arquivado"
+  fi
+done
+
+log "🎉" "Arquivamento concluído!"
+log "📝" "Todos os repositórios foram consolidados no monorepo xMatVerse"
+

--- a/scripts/consolidation/migrate-to-monorepo.sh
+++ b/scripts/consolidation/migrate-to-monorepo.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# scripts/consolidation/migrate-to-monorepo.sh
+#
+# Consolidates MatVerse related repositories into a single monorepo layout.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+SECTION_BREAK="=================================================="
+
+log "🚀" "Iniciando processo de consolidação MatVerse..."
+printf '%s\n' "$SECTION_BREAK"
+
+# Allow overriding via environment variables so the script can be tested easily.
+MAIN_REPO=${MAIN_REPO:-"https://github.com/xMatVerse/xMatVerse.git"}
+EXPLORE_REPO=${EXPLORE_REPO:-"https://github.com/xMatVerse/matverse-explore.git"}
+SYMBIOS_REPO=${SYMBIOS_REPO:-"https://github.com/xMatVerse/SymbiOS-public.git"}
+TEMP_DIR=${TEMP_DIR:-"./temp-consolidation"}
+FINAL_DIR=${FINAL_DIR:-"./xMatVerse-monorepo"}
+TEMPLATE_DIR=${TEMPLATE_DIR:-"../templates"}
+INITIAL_COMMIT_MESSAGE=${INITIAL_COMMIT_MESSAGE:-"feat: initial monorepo consolidation"}
+
+# Helper to ensure we are working with absolute paths inside the script.
+resolve_path() {
+  local path="$1"
+  if [[ "$path" = /* ]]; then
+    printf '%s' "$path"
+  else
+    printf '%s/%s' "$(pwd)" "$path"
+  fi
+}
+
+TEMP_DIR=$(resolve_path "$TEMP_DIR")
+FINAL_DIR=$(resolve_path "$FINAL_DIR")
+TEMPLATE_DIR=$(resolve_path "$TEMPLATE_DIR")
+
+cleanup() {
+  if [[ -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v git >/dev/null 2>&1; then
+  log "❌" "Git não encontrado. Instale git para continuar."
+  exit 1
+fi
+
+if [[ -d "$TEMP_DIR" ]]; then
+  log "ℹ️" "Removendo diretório temporário existente em $TEMP_DIR"
+  rm -rf "$TEMP_DIR"
+fi
+
+mkdir -p "$TEMP_DIR"
+cd "$TEMP_DIR"
+
+log "📦" "Clonando repositórios..."
+
+git clone --depth 1 "$MAIN_REPO" main-repo
+log "✅" "Repositório principal clonado."
+
+git clone --depth 1 "$EXPLORE_REPO" explore-repo
+log "✅" "MatVerse Explore clonado."
+
+git clone --depth 1 "$SYMBIOS_REPO" symbios-repo
+log "✅" "SymbiOS clonado."
+
+log "🏗️" "Criando estrutura do monorepo..."
+
+mkdir -p "$FINAL_DIR"
+cp -a main-repo/. "$FINAL_DIR/"
+rm -rf "$FINAL_DIR/.git"
+
+copy_with_dotfiles() {
+  local source_dir="$1"
+  local target_dir="$2"
+  mkdir -p "$target_dir"
+  (shopt -s dotglob nullglob; cp -a "$source_dir"/* "$target_dir"/ 2>/dev/null || true)
+}
+
+log "📂" "Migrando MatVerse Explore..."
+copy_with_dotfiles "explore-repo" "$FINAL_DIR/apps/explore"
+rm -rf "$FINAL_DIR/apps/explore/.git"
+
+log "📂" "Migrando SymbiOS..."
+copy_with_dotfiles "symbios-repo" "$FINAL_DIR/apps/symbios"
+rm -rf "$FINAL_DIR/apps/symbios/.git"
+
+log "📝" "Configurando package.json principal..."
+cat > "$FINAL_DIR/package.json" <<'JSON'
+{
+  "name": "xmatverse-monorepo",
+  "version": "1.0.0",
+  "description": "MatVerse Ecosystem - Monorepo completo",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "concurrently \"npm run dev:explore\" \"npm run dev:symbios\" \"npm run dev:cog-ui\"",
+    "dev:explore": "cd apps/explore && npm run dev",
+    "dev:symbios": "cd apps/symbios && go run main.go serve",
+    "dev:cog-ui": "cd apps/cog-ui && npm run dev",
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces",
+    "test:ci": "npm run test:ci --workspaces",
+    "lint": "npm run lint --workspaces",
+    "docker:up": "docker-compose -f infra/docker-compose.yml up -d",
+    "docker:down": "docker-compose -f infra/docker-compose.yml down",
+    "lakehouse:init": "scripts/verification/verify-lakehouse.sh",
+    "status": "scripts/status/healthcheck.sh"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  }
+}
+JSON
+
+log "⚙️" "Configurando arquivos de configuração adicionais..."
+if [[ -d "$TEMPLATE_DIR" && -n "$(ls -A "$TEMPLATE_DIR" 2>/dev/null)" ]]; then
+  cp -a "$TEMPLATE_DIR"/. "$FINAL_DIR"/
+else
+  log "ℹ️" "Nenhum template encontrado em $TEMPLATE_DIR. Pulando etapa."
+fi
+
+log "🔨" "Inicializando repositório git..."
+cd "$FINAL_DIR"
+
+git init >/dev/null
+if git status --short >/dev/null 2>&1 && [[ -n "$(git status --short)" ]]; then
+  git add .
+  git commit -m "$INITIAL_COMMIT_MESSAGE" >/dev/null
+  log "✅" "Commit inicial criado."
+else
+  log "ℹ️" "Nenhuma alteração a commitar."
+fi
+
+log "✅" "Consolidação concluída!"
+log "📁" "Diretório final: $FINAL_DIR"
+log "🚀" "Para iniciar: cd $FINAL_DIR && npm install && npm run docker:up"
+

--- a/scripts/debug/generate-debug-report.sh
+++ b/scripts/debug/generate-debug-report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scripts/debug/generate-debug-report.sh
+#
+# Collects a comprehensive debug snapshot for troubleshooting MatVerse deployments.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+output_dir="logs/debug"
+mkdir -p "$output_dir"
+report_file="$output_dir/debug-report-$(date +%Y%m%d-%H%M%S).txt"
+
+log "📝" "Gerando relatório de debug em $report_file"
+
+{
+  printf 'MatVerse Debug Report - %s\n' "$(date)"
+  printf '=================================\n\n'
+
+  printf '## System Information\n'
+  printf '=====================\n'
+  uname -a 2>&1 || printf 'uname indisponível\n'
+  printf '\n'
+
+  printf '## Resource Usage\n'
+  printf '=================\n'
+  free -h 2>&1 || printf 'free indisponível\n'
+  printf '\n'
+  df -h . 2>&1 || printf 'df indisponível\n'
+  printf '\n'
+
+  printf '## Network Information\n'
+  printf '======================\n'
+  if command -v ifconfig >/dev/null 2>&1; then
+    ifconfig 2>&1
+  elif command -v ip >/dev/null 2>&1; then
+    ip addr 2>&1
+  else
+    printf 'Ferramentas de rede indisponíveis\n'
+  fi
+  printf '\n'
+
+  printf '## Docker Status\n'
+  printf '================\n'
+  if command -v docker >/dev/null 2>&1; then
+    docker info 2>&1 || printf 'docker info falhou\n'
+    printf '\n'
+    docker ps -a 2>&1 || printf 'docker ps falhou\n'
+  else
+    printf 'Docker não instalado\n'
+  fi
+  printf '\n'
+
+  printf '## Service Status\n'
+  printf '=================\n'
+  if command -v ss >/dev/null 2>&1; then
+    ss -tulpn 2>&1
+  elif command -v netstat >/dev/null 2>&1; then
+    netstat -tulpn 2>&1
+  else
+    printf 'Ferramentas ss/netstat indisponíveis\n'
+  fi
+  printf '\n'
+
+  printf '## Process Information\n'
+  printf '======================\n'
+  ps aux | grep -E '(node|go|docker)' | head -20 2>&1 || printf 'ps indisponível\n'
+  printf '\n'
+
+  printf '## Environment Variables\n'
+  printf '========================\n'
+  printenv | grep -E '(MATVERSE|NODE|GO|DOCKER)' | sort 2>/dev/null || printf 'Variáveis relevantes não encontradas\n'
+  printf '\n'
+
+  printf '## Log Files (últimas 5 linhas)\n'
+  printf '================================\n'
+  find . -name '*.log' -type f -print0 2>/dev/null | while IFS= read -r -d '' logfile; do
+    printf '-- %s --\n' "$logfile"
+    tail -n 5 "$logfile" 2>/dev/null || printf 'Não foi possível ler %s\n' "$logfile"
+    printf '\n'
+  done
+} >"$report_file"
+
+log "✅" "Relatório de debug salvo em $report_file"

--- a/scripts/deployment/deploy-production.sh
+++ b/scripts/deployment/deploy-production.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/deployment/deploy-production.sh
+#
+# Builds and deploys the MatVerse monorepo to the desired environment.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🚀" "Iniciando deploy de produção..."
+printf '===================================%s\n' ""
+
+ENVIRONMENT=${1:-staging}
+REGISTRY=${REGISTRY:-"ghcr.io/xmatverse"}
+TAG=${TAG:-}
+
+if [[ -z "$TAG" ]]; then
+  if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    TAG=$(git rev-parse --short HEAD)
+  else
+    TAG=$(date +%Y%m%d%H%M%S)
+  fi
+fi
+
+log "🔖" "Deploying version: $TAG to: $ENVIRONMENT"
+
+if [[ ! -f "package.json" ]]; then
+  log "❌" "Execute este script a partir do diretório raiz do monorepo"
+  exit 1
+fi
+
+required_cmds=(docker $([[ -d infra/terraform ]] && echo terraform) kubectl)
+missing_cmds=()
+for cmd in "${required_cmds[@]}"; do
+  if [[ -n "$cmd" && ! $(command -v "$cmd") ]]; then
+    missing_cmds+=("$cmd")
+  fi
+done
+
+if ((${#missing_cmds[@]})); then
+  log "❌" "Comandos ausentes:" && printf ' - %s\n' "${missing_cmds[@]}"
+  exit 1
+fi
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    compose_cmd=""
+  fi
+fi
+
+build_and_push() {
+  local image_name="$1"
+  local dockerfile="$2"
+
+  if [[ ! -f "$dockerfile" ]]; then
+    log "⚠️" "Dockerfile não encontrado em $dockerfile. Pulando imagem $image_name."
+    return
+  fi
+
+  log "🐳" "Construindo imagem $image_name..."
+  docker build -t "$REGISTRY/$image_name:$TAG" -f "$dockerfile" .
+
+  log "📤" "Enviando $image_name para $REGISTRY..."
+  docker push "$REGISTRY/$image_name:$TAG"
+}
+
+build_and_push "explore" "apps/explore/Dockerfile"
+build_and_push "symbios" "apps/symbios/Dockerfile"
+build_and_push "cog-ui" "apps/cog-ui/Dockerfile"
+build_and_push "lakehouse-ingest" "packages/lakehouse/ingest/Dockerfile"
+build_and_push "lakehouse-transform" "packages/lakehouse/transform/Dockerfile"
+
+if [[ -d infra/terraform/$ENVIRONMENT ]]; then
+  log "⚙️" "Aplicando configurações de infraestrutura..."
+  pushd "infra/terraform/$ENVIRONMENT" >/dev/null
+  terraform init
+  terraform apply -auto-approve -var="image_tag=$TAG"
+  popd >/dev/null
+else
+  log "⚠️" "Diretório infra/terraform/$ENVIRONMENT não encontrado. Pulando etapa de Terraform."
+fi
+
+if command -v kubectl >/dev/null 2>&1; then
+  log "🔄" "Executando migrações de banco..."
+  if kubectl exec deployment/symbios -- ./migrate up; then
+    log "✅" "Migrações executadas com sucesso."
+  else
+    log "⚠️" "Falha ao executar migrações. Verifique o log do pod symbios."
+  fi
+else
+  log "⚠️" "kubectl não encontrado. Pulando migrações."
+fi
+
+VERIFY_SCRIPT="./scripts/verification/verify-deployment.sh"
+if [[ -x "$VERIFY_SCRIPT" ]]; then
+  log "🔍" "Verificando deploy..."
+  "$VERIFY_SCRIPT" "$ENVIRONMENT"
+else
+  log "⚠️" "Script de verificação de deploy não encontrado em $VERIFY_SCRIPT."
+fi
+
+log "✅" "Deploy concluído com sucesso!"
+log "🌐" "URLs sugeridas:"
+log "   -" "Explore: https://explore.$ENVIRONMENT.matverse.ai"
+log "   -" "SymbiOS: https://symbios.$ENVIRONMENT.matverse.ai"
+log "   -" "Cog UI: https://cog.$ENVIRONMENT.matverse.ai"
+

--- a/scripts/quick-check.sh
+++ b/scripts/quick-check.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# scripts/quick-check.sh
+#
+# Runs a lightweight readiness check for the MatVerse environment.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+quick_check() {
+  local message="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    log "✅" "$message"
+  else
+    log "❌" "$message"
+  fi
+}
+
+log "🎯" "Verificação Rápida do Ambiente"
+printf '================================\n'
+
+printf '🔍 Verificações básicas:\n'
+quick_check "Node.js disponível" command -v node
+quick_check "npm disponível" command -v npm
+quick_check "Go disponível" command -v go
+quick_check "Docker disponível" command -v docker
+quick_check "Docker Compose disponível" bash -c 'command -v docker-compose >/dev/null 2>&1 || docker compose version >/dev/null 2>&1'
+quick_check "Diretório raiz correto" test -f package.json
+quick_check "Arquivo .env existe" test -f .env
+if command -v docker >/dev/null 2>&1; then
+  quick_check "Docker rodando" docker info
+else
+  log "⚠️" "Docker não instalado"
+fi
+printf '\n'
+
+printf '📦 Verificações de dependências:\n'
+quick_check "Dependências Node instaladas" test -d node_modules
+if [[ -d apps/symbios ]]; then
+  quick_check "Dependências Go instaladas" test -d apps/symbios/vendor
+else
+  log "⚠️" "apps/symbios não encontrado"
+fi
+printf '\n'
+
+printf '🌐 Verificações de rede:\n'
+if command -v nc >/dev/null 2>&1; then
+  quick_check "Porta 3000 livre" bash -c '! nc -z localhost 3000 >/dev/null 2>&1'
+  quick_check "Porta 8080 livre" bash -c '! nc -z localhost 8080 >/dev/null 2>&1'
+else
+  log "⚠️" "Ferramenta nc indisponível. Pulando checagem de portas."
+fi
+if command -v ping >/dev/null 2>&1; then
+  quick_check "Conexão com internet" ping -c 1 github.com
+else
+  log "⚠️" "ping indisponível."
+fi
+printf '\n'
+
+log "✅" "Verificação rápida concluída!"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/quickstart.sh
+#
+# Bootstraps a local MatVerse environment quickly.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🚀" "Inicialização Rápida MatVerse"
+printf '================================%s\n' ""
+
+if [[ ! -f package.json ]]; then
+  log "❌" "package.json não encontrado. Execute este script na raiz do monorepo."
+  exit 1
+fi
+
+log "🔍" "Verificando dependências..."
+required_cmds=(node npm go docker)
+missing_cmds=()
+for cmd in "${required_cmds[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    missing_cmds+=("$cmd")
+  fi
+done
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    missing_cmds+=("docker-compose")
+  fi
+fi
+
+if ((${#missing_cmds[@]})); then
+  log "❌" "Dependências ausentes:" && printf ' - %s\n' "${missing_cmds[@]}"
+  exit 1
+fi
+
+log "📦" "Instalando dependências..."
+npm install
+
+log "🐳" "Iniciando Docker Compose..."
+$compose_cmd -f infra/docker-compose.yml up -d
+
+log "⏳" "Aguardando inicialização dos serviços..."
+sleep 30
+
+log "🔍" "Executando verificações..."
+npm run lakehouse:init
+
+log "🏗️" "Construindo aplicativos..."
+npm run build
+
+log "🚀" "Iniciando serviços..."
+npm run dev &
+DEV_PID=$!
+
+log "🎉" "MatVerse inicializado com sucesso!"
+printf '🌐 URLs disponíveis:\n'
+printf '   - Explore: http://localhost:3000\n'
+printf '   - SymbiOS: http://localhost:8080\n'
+printf '   - MinIO Console: http://localhost:9001\n'
+printf '   - Grafana: http://localhost:3001\n\n'
+printf '📊 Para verificar status: npm run status\n'
+printf '🛑 Para interromper os serviços de desenvolvimento: kill %s\n' "$DEV_PID"
+

--- a/scripts/start-with-fallback.sh
+++ b/scripts/start-with-fallback.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# scripts/start-with-fallback.sh
+#
+# Starts the MatVerse environment with retry/fallback logic.
+
+set -euo pipefail
+
+MAX_RETRIES=${MAX_RETRIES:-3}
+RETRY_DELAY=${RETRY_DELAY:-5}
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+repo_root=$(pwd)
+log_dir="$repo_root/logs/start-with-fallback"
+mkdir -p "$log_dir"
+
+background_pids=()
+
+start_service() {
+  local name="$1"
+  shift
+  local attempt=1
+  while (( attempt <= MAX_RETRIES )); do
+    if "$@"; then
+      log "✅" "$name iniciado com sucesso"
+      return 0
+    fi
+    ((attempt++))
+    if (( attempt <= MAX_RETRIES )); then
+      log "⚠️" "Tentativa $((attempt-1)) para $name falhou. Repetindo em ${RETRY_DELAY}s..."
+      sleep "$RETRY_DELAY"
+    fi
+  done
+  log "❌" "Falha ao iniciar $name após ${MAX_RETRIES} tentativas"
+  return 1
+}
+
+start_background_service() {
+  local name="$1"
+  local dir="$2"
+  shift 2
+  local attempt=1
+  local sanitized
+  sanitized=$(echo "$name" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')
+  local log_file="$log_dir/${sanitized:-service}.log"
+
+  while (( attempt <= MAX_RETRIES )); do
+    if [[ ! -d "$dir" ]]; then
+      log "❌" "Diretório ${dir} ausente para $name"
+      return 1
+    fi
+
+    local pid
+    if ! pid=$(cd "$dir" && nohup "$@" >>"$log_file" 2>&1 & echo $!); then
+      log "⚠️" "Não foi possível iniciar $name"
+      pid=""
+    fi
+    sleep 3
+    if [[ -n "$pid" ]] && ps -p "$pid" >/dev/null 2>&1; then
+      background_pids+=("$name:$pid:$log_file")
+      log "✅" "$name iniciado (PID $pid, log em $log_file)"
+      return 0
+    fi
+
+    log "⚠️" "Tentativa $attempt para $name falhou. Verifique $log_file"
+    ((attempt++))
+    if (( attempt <= MAX_RETRIES )); then
+      sleep "$RETRY_DELAY"
+    fi
+  done
+  log "❌" "Falha ao iniciar $name após ${MAX_RETRIES} tentativas"
+  return 1
+}
+
+log "🚀" "Inicialização com Fallback"
+printf '=============================\n'
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    compose_cmd=""
+  fi
+fi
+
+if [[ -n "$compose_cmd" && -f infra/docker-compose.yml ]]; then
+  start_service "Docker Compose" $compose_cmd -f infra/docker-compose.yml up -d
+else
+  log "⚠️" "docker-compose indisponível ou infra/docker-compose.yml ausente. Pulando inicialização de containers."
+fi
+
+start_background_service "Explore Frontend" "apps/explore" npm start || true
+start_background_service "SymbiOS Backend" "apps/symbios" go run main.go serve || true
+
+log "⏳" "Aguardando inicialização completa..."
+sleep 10
+
+if [[ -x scripts/troubleshooting/diagnose-fix.sh ]]; then
+  log "🔍" "Executando diagnóstico final..."
+  scripts/troubleshooting/diagnose-fix.sh || log "⚠️" "Diagnóstico reportou problemas"
+else
+  log "⚠️" "scripts/troubleshooting/diagnose-fix.sh não encontrado ou sem permissão de execução"
+fi
+
+if ((${#background_pids[@]})); then
+  printf '\nServiços em execução:\n'
+  for entry in "${background_pids[@]}"; do
+    IFS=':' read -r name pid logfile <<<"$entry"
+    printf ' - %s (PID %s, log: %s)\n' "$name" "$pid" "$logfile"
+  done
+fi
+
+log "🎉" "Ambiente MatVerse inicializado com resiliência!"

--- a/scripts/status/healthcheck.sh
+++ b/scripts/status/healthcheck.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scripts/status/healthcheck.sh
+#
+# Provides an overview of the MatVerse stack status.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+printf '📊 Status do Sistema MatVerse\n'
+printf '==============================\n'
+printf 'Data: %s\n\n' "$(date)"
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    compose_cmd=""
+  fi
+fi
+
+if [[ -n "$compose_cmd" && -f infra/docker-compose.yml ]]; then
+  printf '🔄 Serviços em execução:\n'
+  $compose_cmd -f infra/docker-compose.yml ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+  printf '\n'
+else
+  printf '⚠️  docker-compose não está disponível ou infra/docker-compose.yml ausente.\n\n'
+fi
+
+printf '📈 Utilização de recursos:\n'
+if command -v top >/dev/null 2>&1; then
+  CPU=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+else
+  CPU="N/A"
+fi
+if command -v free >/dev/null 2>&1; then
+  MEM=$(free -m | awk 'NR==2{printf "%.2f%%", $3*100/$2}')
+else
+  MEM="N/A"
+fi
+if df -h / >/dev/null 2>&1; then
+  DISK=$(df -h / | awk 'NR==2{print $5}')
+else
+  DISK="N/A"
+fi
+printf 'CPU: %s\n' "$CPU"
+printf 'Memória: %s\n' "$MEM"
+printf 'Disco: %s\n\n' "$DISK"
+
+printf '🌐 Status dos aplicativos:\n'
+check_url() {
+  local url="$1"
+  if command -v curl >/dev/null 2>&1 && curl -s -o /dev/null -w "%{http_code}" "$url" | grep -q "200"; then
+    printf '✅ %s\n' "$url"
+  else
+    printf '❌ %s\n' "$url"
+  fi
+}
+
+check_url http://localhost:3000    # Explore
+check_url http://localhost:8080    # SymbiOS
+check_url http://localhost:9001    # MinIO Console
+check_url http://localhost:9090    # Prometheus
+check_url http://localhost:3001    # Grafana
+printf '\n'
+
+if [[ -n "$compose_cmd" ]]; then
+  printf '📊 Métricas do Lakehouse:\n'
+  if command -v docker >/dev/null 2>&1; then
+    INGEST=$($compose_cmd exec redis redis-cli GET metrics:ingest:total 2>/dev/null || echo "N/A")
+    INDEX_SIZE=$($compose_cmd exec trino trino --catalog iceberg --schema cog -e "SELECT COUNT(*) FROM silver_documents" 2>/dev/null | tail -1 || echo "N/A")
+    printf 'Documentos ingestados: %s\n' "${INGEST:-N/A}"
+    printf 'Tamanho do índice FAISS: %s\n' "${INDEX_SIZE:-N/A}"
+  else
+    printf '⚠️  Docker não disponível. Não foi possível coletar métricas.\n'
+  fi
+  printf '\n'
+fi
+
+printf '✅ Verificação de status concluída\n'
+

--- a/scripts/test/connectivity-test.sh
+++ b/scripts/test/connectivity-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# scripts/test/connectivity-test.sh
+#
+# Validates external and internal connectivity required for MatVerse services.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🧪" "Teste de Conectividade"
+printf '========================\n'
+
+check_external() {
+  local host="$1"
+  local label="$2"
+  if ! command -v ping >/dev/null 2>&1; then
+    log "⚠️" "ping indisponível. Não foi possível testar $label ($host)"
+    return 1
+  fi
+
+  if ping -c 1 "$host" >/dev/null 2>&1; then
+    log "✅" "$label: Conectado"
+  else
+    log "❌" "$label: Falha"
+  fi
+}
+
+check_port() {
+  local port="$1"
+  local service="$2"
+  if command -v nc >/dev/null 2>&1; then
+    if nc -z localhost "$port" >/dev/null 2>&1; then
+      log "✅" "$service: Rodando na porta $port"
+    else
+      log "❌" "$service: Não está rodando na porta $port"
+    fi
+  elif command -v ss >/dev/null 2>&1; then
+    if ss -ltn | awk '{print $4}' | grep -qE ":${port}$"; then
+      log "✅" "$service: Rodando na porta $port"
+    else
+      log "❌" "$service: Não está rodando na porta $port"
+    fi
+  else
+    log "⚠️" "Ferramentas nc/ss indisponíveis. Não foi possível testar $service"
+  fi
+}
+
+printf '🌐 Testando conexões externas...\n'
+check_external github.com "GitHub"
+check_external docker.com "Docker Hub"
+check_external huggingface.co "Hugging Face"
+printf '\n'
+
+printf '🏠 Testando serviços locais...\n'
+declare -A local_ports=(
+  [3000]="Explore Frontend"
+  [8080]="SymbiOS Backend"
+  [9000]="MinIO"
+  [9001]="MinIO Console"
+  [8081]="Trino"
+  [6379]="Redis"
+  [9090]="Prometheus"
+  [3001]="Grafana"
+)
+for port in "${!local_ports[@]}"; do
+  check_port "$port" "${local_ports[$port]}"
+done
+printf '\n'
+
+printf '🔧 Testando ferramentas...\n'
+for tool in node go docker python3; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    log "✅" "$tool: Instalado"
+  else
+    log "❌" "$tool: Faltando"
+  fi
+done
+
+log "📊" "Teste de conectividade concluído!"

--- a/scripts/troubleshooting/diagnose-fix.sh
+++ b/scripts/troubleshooting/diagnose-fix.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# scripts/troubleshooting/diagnose-fix.sh
+#
+# Performs an environment diagnosis and applies corrective actions for the MatVerse stack.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+print_version() {
+  local label="$1"
+  shift
+  local cmd=("$@")
+  if command -v "${cmd[0]}" >/dev/null 2>&1; then
+    local version
+    if version="$("${cmd[@]}" 2>&1)"; then
+      log "ℹ️" "$label: $version"
+    else
+      log "⚠️" "$label: ${cmd[0]} --version falhou"
+    fi
+  else
+    log "⚠️" "$label não instalado"
+  fi
+}
+
+log "🔧" "Diagnóstico e Correção do Ambiente MatVerse"
+printf '==============================================\n'
+
+print_version "Node.js" node --version
+print_version "npm" npm --version
+print_version "Go" go version
+print_version "Python" python3 --version
+print_version "Docker" docker --version
+if command -v docker-compose >/dev/null 2>&1; then
+  print_version "Docker Compose" docker-compose --version
+elif docker compose version >/dev/null 2>&1; then
+  print_version "Docker Compose" docker compose version
+else
+  log "⚠️" "Docker Compose não instalado"
+fi
+
+if [[ ! -f package.json ]]; then
+  log "❌" "Não está no diretório raiz do projeto (package.json ausente). Diretório atual: $(pwd)"
+  exit 1
+fi
+
+log "🔒" "Verificando permissões de scripts..."
+if [[ -d scripts ]]; then
+  while IFS= read -r -d '' script_file; do
+    chmod +x "$script_file"
+  done < <(find scripts -type f -name '*.sh' -print0)
+fi
+log "✅" "Permissões ajustadas"
+
+log "📦" "Verificando dependências Node.js..."
+if command -v npm >/dev/null 2>&1; then
+  if [[ ! -d node_modules ]]; then
+    log "🛠️" "Instalando dependências Node.js..."
+    npm install
+  else
+    log "✅" "Dependências Node.js já instaladas"
+  fi
+else
+  log "❌" "npm não encontrado. Instale Node.js/npm antes de prosseguir."
+  exit 1
+fi
+
+if [[ -d apps/symbios ]]; then
+  log "📦" "Verificando dependências Go (apps/symbios)..."
+  if command -v go >/dev/null 2>&1; then
+    pushd apps/symbios >/dev/null
+    if [[ ! -d vendor ]]; then
+      log "🛠️" "Instalando dependências Go..."
+      go mod download
+    else
+      log "✅" "Dependências Go já instaladas"
+    fi
+    popd >/dev/null
+  else
+    log "⚠️" "Go não instalado. Pulando verificação das dependências Go."
+  fi
+else
+  log "⚠️" "Diretório apps/symbios não encontrado. Pulando verificação Go."
+fi
+
+log "🐳" "Verificando Docker..."
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  log "✅" "Docker em execução"
+else
+  log "❌" "Docker não está rodando. Inicie o serviço (ex: sudo systemctl start docker)."
+  exit 1
+fi
+
+log "🔌" "Verificando portas..."
+declare -A ports=(
+  [3000]="Explore"
+  [8080]="SymbiOS"
+  [9000]="MinIO"
+  [9001]="MinIO Console"
+  [8081]="Trino"
+  [6379]="Redis"
+  [9090]="Prometheus"
+  [3001]="Grafana"
+)
+
+check_port() {
+  local port="$1"
+  local description="$2"
+  if command -v nc >/dev/null 2>&1; then
+    if nc -z localhost "$port" >/dev/null 2>&1; then
+      log "⚠️" "Porta $port (${description}) já está em uso"
+    else
+      log "✅" "Porta $port (${description}) disponível"
+    fi
+  elif command -v ss >/dev/null 2>&1; then
+    if ss -ltn | awk '{print $4}' | grep -qE ":${port}$"; then
+      log "⚠️" "Porta $port (${description}) já está em uso"
+    else
+      log "✅" "Porta $port (${description}) disponível"
+    fi
+  else
+    log "⚠️" "Não foi possível verificar a porta $port (${description}). Ferramenta nc/ss indisponível."
+  fi
+}
+
+for port in "${!ports[@]}"; do
+  check_port "$port" "${ports[$port]}"
+done
+
+log "🌐" "Verificando variáveis de ambiente..."
+if [[ -f .env ]]; then
+  log "✅" ".env encontrado"
+elif [[ -f .env.example ]]; then
+  cp .env.example .env
+  log "⚠️" "Arquivo .env criado a partir de .env.example. Revise as variáveis."
+else
+  log "⚠️" "Nenhum arquivo .env ou .env.example encontrado"
+fi
+
+log "📡" "Testando conectividade externa..."
+if command -v ping >/dev/null 2>&1; then
+  if ping -c 1 github.com >/dev/null 2>&1; then
+    log "✅" "Conexão com a internet OK"
+  else
+    log "❌" "Falha na conexão com a internet"
+  fi
+else
+  log "⚠️" "Comando ping indisponível. Não foi possível testar a conexão."
+fi
+
+log "💾" "Verificando espaço em disco..."
+df -h . || log "⚠️" "Não foi possível obter uso de disco"
+
+log "✅" "Diagnóstico concluído. Execute ./scripts/quickstart.sh para iniciar o ambiente."

--- a/scripts/troubleshooting/fix-common-issues.sh
+++ b/scripts/troubleshooting/fix-common-issues.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/troubleshooting/fix-common-issues.sh
+#
+# Applies a set of corrective actions for recurring environment issues.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🐛" "Correção de Problemas Comuns"
+printf '================================\n'
+
+step=1
+
+log "${step}." "Corrigindo permissões Docker..."
+if command -v docker >/dev/null 2>&1; then
+  if groups "$USER" | grep -qw docker; then
+    log "✅" "Usuário já pertence ao grupo docker"
+  else
+    if command -v sudo >/dev/null 2>&1; then
+      if sudo usermod -aG docker "$USER"; then
+        log "🛠️" "Usuário adicionado ao grupo docker. Reinicie a sessão ou execute: newgrp docker"
+      else
+        log "⚠️" "Não foi possível ajustar o grupo docker"
+      fi
+    elif [[ "$EUID" -eq 0 ]]; then
+      target_user=${SUDO_USER:-}
+      if [[ -n "$target_user" ]]; then
+        if usermod -aG docker "$target_user" 2>/dev/null; then
+          log "🛠️" "Usuário ${target_user} adicionado ao grupo docker"
+        else
+          log "⚠️" "Não foi possível ajustar o grupo docker"
+        fi
+      else
+        log "ℹ️" "Execute como usuário final (ex: via sudo) para ajustar o grupo docker."
+      fi
+      unset target_user
+    else
+      log "⚠️" "sudo não disponível. Ajuste manualmente o grupo docker."
+    fi
+  fi
+else
+  log "⚠️" "Docker não instalado. Pulando etapa."
+fi
+((step++))
+
+log "${step}." "Limpando cache Docker..."
+if command -v docker >/dev/null 2>&1; then
+  docker system prune -f || log "⚠️" "Não foi possível limpar o cache Docker"
+else
+  log "⚠️" "Docker não instalado. Pulando etapa."
+fi
+((step++))
+
+log "${step}." "Reinstalando dependências Node.js..."
+if command -v npm >/dev/null 2>&1; then
+  rm -rf node_modules package-lock.json
+  npm install
+else
+  log "⚠️" "npm não disponível. Pulando reinstalação."
+fi
+((step++))
+
+log "${step}." "Reinstalando dependências Go..."
+if command -v go >/dev/null 2>&1 && [[ -d apps/symbios ]]; then
+  pushd apps/symbios >/dev/null
+  rm -rf vendor go.sum
+  go mod download
+  popd >/dev/null
+else
+  log "⚠️" "Go não disponível ou diretório apps/symbios ausente."
+fi
+((step++))
+
+log "${step}." "Parando serviços em conflito..."
+pkill -f "node" >/dev/null 2>&1 || true
+pkill -f "go run" >/dev/null 2>&1 || true
+pkill -f "npm" >/dev/null 2>&1 || true
+log "✅" "Serviços conflitantes interrompidos (quando existentes)"
+((step++))
+
+log "${step}." "Verificando firewall..."
+if command -v ufw >/dev/null 2>&1; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo ufw allow 3000 8080 9000 9001 >/dev/null 2>&1 || true
+  elif [[ "$EUID" -eq 0 ]]; then
+    ufw allow 3000 8080 9000 9001 >/dev/null 2>&1 || true
+  else
+    log "⚠️" "Permissões insuficientes para ajustar firewall"
+  fi
+  log "✅" "Regras básicas de firewall aplicadas"
+else
+  log "ℹ️" "ufw não encontrado. Pulando etapa."
+fi
+((step++))
+
+log "${step}." "Avaliando memória disponível..."
+if command -v free >/dev/null 2>&1; then
+  total_mem=$(free -m | awk '/Mem:/ {print $2}')
+  if [[ -n "$total_mem" && "$total_mem" -lt 4096 ]]; then
+    export NODE_OPTIONS="--max-old-space-size=2048"
+    log "⚠️" "Memória detectada (${total_mem}MB) abaixo de 4GB. NODE_OPTIONS ajustado para 2GB."
+  else
+    log "✅" "Memória suficiente detectada (${total_mem}MB)"
+  fi
+else
+  log "⚠️" "Não foi possível determinar a memória disponível"
+fi
+
+log "✅" "Correções aplicadas!"

--- a/scripts/verification/final-checklist.sh
+++ b/scripts/verification/final-checklist.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/verification/final-checklist.sh
+#
+# Interactive checklist used before declaring the consolidation finished.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "✅" "Checklist Final de Consolidação"
+printf '=================================%s\n' ""
+
+checks=(
+  "Estrutura de diretórios completa"
+  "Build bem-sucedido de todos os componentes"
+  "Serviços Docker em execução"
+  "Conexão com MinIO funcionando"
+  "Conexão com Trino funcionando"
+  "Redis respondendo"
+  "Testes passando"
+  "Configuração de CI/CD válida"
+  "Documentação atualizada"
+  "Variáveis de ambiente configuradas"
+)
+
+for check in "${checks[@]}"; do
+  while true; do
+    read -rp "$check (y/n): " -n 1 response
+    printf '\n'
+    case "$response" in
+      [Yy]) break ;;
+      [Nn])
+        log "❌" "Checklist incompleto: $check"
+        exit 1
+        ;;
+      *) printf 'Por favor responda com y ou n.\n' ;;
+    esac
+  done
+  log "✅" "$check verificado"
+done
+
+log "🎉" "Checklist completo! MatVerse está pronto para produção!"
+

--- a/scripts/verification/verify-consolidation.sh
+++ b/scripts/verification/verify-consolidation.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# scripts/verification/verify-consolidation.sh
+#
+# Performs a comprehensive verification of the MatVerse monorepo consolidation.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🔍" "Verificando integridade da consolidação..."
+printf '=============================================%s\n' ""
+
+ROOT_DIR=$(pwd)
+
+# Ensure we are running from the repository root.
+if [[ ! -f "package.json" ]]; then
+  log "⚠️" "package.json não encontrado no diretório atual ($ROOT_DIR)."
+  log "ℹ️" "Execute este script a partir da raiz do monorepo consolidado."
+  exit 1
+fi
+
+log "📁" "Verificando estrutura de diretórios..."
+required_dirs=(
+  "apps/explore"
+  "apps/symbios"
+  "apps/cog-ui"
+  "packages/core"
+  "packages/lakehouse"
+  "packages/lakehouse/ingest"
+  "packages/lakehouse/transform"
+  "packages/cognitive"
+  "packages/security"
+  "infra"
+  "scripts"
+  "docs"
+)
+
+missing_dirs=()
+for dir in "${required_dirs[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    missing_dirs+=("$dir")
+  fi
+done
+
+if ((${#missing_dirs[@]})); then
+  log "❌" "Diretórios faltando:" && printf ' - %s\n' "${missing_dirs[@]}"
+  exit 1
+fi
+
+log "✅" "Estrutura de diretórios encontrada."
+
+log "📄" "Verificando arquivos essenciais..."
+required_files=(
+  "package.json"
+  "infra/docker-compose.yml"
+  "README.md"
+  "apps/explore/package.json"
+  "apps/symbios/go.mod"
+  "packages/lakehouse/ingest/go.mod"
+  "packages/lakehouse/transform/go.mod"
+)
+
+missing_files=()
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    missing_files+=("$file")
+  fi
+done
+
+if ((${#missing_files[@]})); then
+  log "❌" "Arquivos essenciais faltando:" && printf ' - %s\n' "${missing_files[@]}"
+  exit 1
+fi
+
+log "✅" "Arquivos essenciais presentes."
+
+log "📦" "Verificando dependências..."
+dependencies=(node go docker)
+missing_bins=()
+for dep in "${dependencies[@]}"; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    missing_bins+=("$dep")
+  fi
+done
+
+if ((${#missing_bins[@]})); then
+  log "❌" "Dependências ausentes:" && printf ' - %s\n' "${missing_bins[@]}"
+  exit 1
+fi
+
+log "✅" "Dependências básicas instaladas."
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    log "❌" "docker-compose não encontrado."
+    exit 1
+  fi
+fi
+
+run_or_skip() {
+  local description="$1"
+  shift
+  local cmd=("$@")
+  log "⏳" "$description"
+  if "${cmd[@]}"; then
+    log "✅" "$description concluído."
+  else
+    log "❌" "Falha em: $description"
+    exit 1
+  fi
+}
+
+log "🏗️" "Testando builds..."
+if [[ -d apps/explore ]]; then
+  (
+    cd apps/explore
+    run_or_skip "Build do MatVerse Explore" bash -lc "npm install --silent && npm run build --silent"
+  )
+fi
+
+if [[ -d apps/symbios ]]; then
+  (cd apps/symbios && run_or_skip "Build do SymbiOS" go build -o /tmp/symbios main.go)
+fi
+
+if [[ -d packages/lakehouse/ingest ]]; then
+  (cd packages/lakehouse/ingest && run_or_skip "Build lakehouse ingest" go build -o /tmp/ingest .)
+fi
+
+if [[ -d packages/lakehouse/transform ]]; then
+  (cd packages/lakehouse/transform && run_or_skip "Build lakehouse transform" go build -o /tmp/transform .)
+fi
+
+log "🐳" "Verificando configuração Docker..."
+$compose_cmd -f infra/docker-compose.yml config --quiet
+log "✅" "Configuração Docker válida."
+
+log "✅" "Verificação concluída com sucesso!"
+log "🎉" "O monorepo está pronto para uso!"
+

--- a/scripts/verification/verify-deployment.sh
+++ b/scripts/verification/verify-deployment.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/verification/verify-deployment.sh
+#
+# Validates a MatVerse deployment running in Kubernetes.
+
+set -euo pipefail
+
+ENVIRONMENT=${1:-staging}
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🔍" "Verificando deploy no ambiente $ENVIRONMENT..."
+printf '============================================%s\n' ""
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  log "❌" "kubectl não encontrado."
+  exit 1
+fi
+
+NAMESPACE=${NAMESPACE:-"matverse-$ENVIRONMENT"}
+
+log "📦" "Listando deployments no namespace $NAMESPACE..."
+if ! kubectl get deployments -n "$NAMESPACE"; then
+  log "❌" "Não foi possível listar deployments."
+  exit 1
+fi
+
+log "🌐" "Verificando ingressos/serviços principais..."
+SERVICES=(
+  "symbios"
+  "explore"
+  "cog-ui"
+)
+for svc in "${SERVICES[@]}"; do
+  if kubectl get service "$svc" -n "$NAMESPACE" >/dev/null 2>&1; then
+    log "✅" "Serviço $svc disponível."
+  else
+    log "⚠️" "Serviço $svc não encontrado."
+  fi
+  if kubectl get ingress "$svc" -n "$NAMESPACE" >/dev/null 2>&1; then
+    log "✅" "Ingress $svc disponível."
+  else
+    log "⚠️" "Ingress $svc não encontrado."
+  fi
+
+done
+
+log "🩺" "Executando verificação de pods..."
+if ! kubectl get pods -n "$NAMESPACE"; then
+  log "❌" "Não foi possível listar pods."
+  exit 1
+fi
+
+log "✅" "Verificação de deploy concluída."
+

--- a/scripts/verification/verify-lakehouse.sh
+++ b/scripts/verification/verify-lakehouse.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scripts/verification/verify-lakehouse.sh
+#
+# Validates the health of the local Lakehouse stack used by MatVerse.
+
+set -euo pipefail
+
+log() {
+  local emoji="$1"
+  shift
+  printf '%s %s\n' "$emoji" "$*"
+}
+
+log "🔍" "Verificando ambiente Lakehouse..."
+printf '====================================%s\n' ""
+
+compose_cmd="docker-compose"
+if ! command -v docker-compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd="docker compose"
+  else
+    log "❌" "docker-compose não encontrado. Instale docker compose plugin ou docker-compose."
+    exit 1
+  fi
+fi
+
+if [[ ! -f infra/docker-compose.yml ]]; then
+  log "❌" "Arquivo infra/docker-compose.yml não encontrado."
+  exit 1
+fi
+
+log "🐳" "Verificando se Docker Compose está rodando..."
+if ! $compose_cmd -f infra/docker-compose.yml ps >/dev/null 2>&1 || \
+   ! $compose_cmd -f infra/docker-compose.yml ps | grep -q "Up"; then
+  log "⚠️" "Docker Compose não está rodando. Iniciando serviços..."
+  $compose_cmd -f infra/docker-compose.yml up -d
+  sleep 30
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  log "❌" "curl não encontrado. Necessário para verificações HTTP."
+  exit 1
+fi
+
+log "🪣" "Testando conexão com MinIO..."
+if curl -s http://localhost:9000/minio/health/live | grep -q "OK"; then
+  log "✅" "MinIO conectado"
+else
+  log "❌" "Falha na conexão com MinIO"
+  exit 1
+fi
+
+log "🐦" "Testando conexão com Trino..."
+if curl -s http://localhost:8080/v1/info | grep -q "starting"; then
+  log "✅" "Trino conectado"
+else
+  log "❌" "Falha na conexão com Trino"
+  exit 1
+fi
+
+log "📊" "Testando consultas no Trino..."
+QUERY_RESULT=$($compose_cmd -f infra/docker-compose.yml exec trino \
+  trino --catalog iceberg --schema cog -e "SHOW TABLES" 2>/dev/null || true)
+
+if grep -q "Table" <<<"$QUERY_RESULT"; then
+  log "✅" "Consultas Trino funcionando"
+else
+  log "⚠️" "Nenhuma tabela encontrada."
+  if [[ -x ./scripts/init-database.sh ]]; then
+    log "ℹ️" "Inicializando banco via scripts/init-database.sh"
+    ./scripts/init-database.sh
+  else
+    log "ℹ️" "Script scripts/init-database.sh não encontrado. Pule esta etapa manualmente."
+  fi
+fi
+
+log "🧠" "Testando conexão com Redis..."
+REDIS_PING=$($compose_cmd -f infra/docker-compose.yml exec redis redis-cli PING 2>/dev/null || true)
+if [[ "$REDIS_PING" == "PONG" ]]; then
+  log "✅" "Redis conectado"
+else
+  log "❌" "Falha na conexão com Redis"
+  exit 1
+fi
+
+log "⚙️" "Testando serviços Go..."
+if [[ -d packages/lakehouse/ingest ]]; then
+  (cd packages/lakehouse/ingest && go test -v ./...)
+fi
+if [[ -d packages/lakehouse/transform ]]; then
+  (cd packages/lakehouse/transform && go test -v ./...)
+fi
+
+log "✅" "Ambiente Lakehouse verificado com sucesso!"
+


### PR DESCRIPTION
## Summary
- add diagnostic, remediation, connectivity, and fallback startup scripts for the MatVerse stack
- collect debug snapshots and quick environment checks from new helper tooling
- document the additional scripts and ignore generated log artifacts

## Testing
- not run (script changes only)

------
https://chatgpt.com/codex/tasks/task_e_68c99e4a609083268ddc917669cea90e